### PR TITLE
Add Download Links To README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ Documentation for YAML files for Avicore Canary Update
 2. `gem install bundle`
 3. `bundle install`
 4. `middleman server`
+
+Download Links:
+
+gem install bundle: http://bundler.io/v1.11/bundle_gem.html
+
+bundle install: http://bundler.io/v1.11/bundle_install.html
+
+middleman server: https://middlemanapp.com/basics/install/


### PR DESCRIPTION
We kinda need download links for ruby, gem and bundler. So people can find the programs a lot easier. Without spending time searching for the programs.
