### PR TITLE
Fix Revisions Link

### DIFF
--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -53,7 +53,7 @@
           %li.pull-right
             %a{:href => "https://maps.avicus.net"} Maps
           %li.pull-right
-            %a{:href => "https://avicus.net/revisions/docs.avicus.net"}
+            %a{:href => "https://avicus.net/revisions/New%20Docs"}
               Revisions
         %br
 


### PR DESCRIPTION
The original link wasn't working. And I found the solution. The Revisions Link Should Be https://avicus.net/revisions/New%20Docs 
Luckily I fixed it. For now I am waiting for this pull request to be mergerd. Oh note: When this gets pushed and If I pop on revisions on avicus could my author name be McFanta_ not McFanta?
