### PR TITLE
Actually fix Revisions Link.

### DIFF
--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -53,7 +53,7 @@
           %li.pull-right
             %a{:href => "https://maps.avicus.net"} Maps
           %li.pull-right
-            %a{:href => "https://avicus.net/revisions/docs.avicus.net"}
+            %a{:href => "https://avicus.net/development/Atlas%20Docs"}
               Revisions
         %br
 


### PR DESCRIPTION
Previously I changed the link to https://avicus.net/revisions/New%20Docs today known as https://avicus.net/development/Avicore%20Docs but Javi reverted it back to https://avicus.net/revisions/docs.avicus.net. But now since Javi, ALM or funky added Atlas Docs the revisions  link should be https://avicus.net/development/Atlas%20Docs not https://avicus.net/development/Avicore%20Docs right? Reply to this if this true and merge it if I am right! 
